### PR TITLE
fix: ensures colours are generated correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -34,6 +34,8 @@ export function colorRotate(hex: string, degrees: number) {
 }
 
 function HexToRGB(hex: string): RGB {
+  hex = hex[0] == '#' ? hex.slice(1, 7) : hex;
+  
   const r = parseInt(hex.slice(0, 2), 16);
   const g = parseInt(hex.slice(2, 4), 16);
   const b = parseInt(hex.slice(4, 6), 16);
@@ -124,5 +126,5 @@ function HSLToHex(hsl: HSL): string {
   if (g_hex.length == 1) g_hex = '0' + g_hex;
   if (b_hex.length == 1) b_hex = '0' + b_hex;
 
-  return '#' + r + g + b;
+  return '#' + r_hex + g_hex + b_hex;
 }


### PR DESCRIPTION
After upgrading to the latest release ([v1.0.1](https://github.com/mirshko/jazzicon-ts/releases/tag/v1.0.1)) all of the generated shapes lost their colors 😢.

This PR patches a couple of places to make sure the HEX -> ... -> HEX flow is carrying the right values.

--

Thank you for all your work here btw @mirshko - you rock!